### PR TITLE
Fixes EGI-FCTF/rOCCI-cli#5, broken ostruct on SL6

### DIFF
--- a/lib/occi-api.rb
+++ b/lib/occi-api.rb
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'rubygems/package'
 
+require 'ostruct'
+
 require 'occi-core'
 
 module Occi::Api; end


### PR DESCRIPTION
Explicitly requiring 'ostruct' prevents loading errors on some
systems.
