### PR TITLE
Removing syntax constructs unsupported in rspec 3

### DIFF
--- a/spec/occi/api/client/client_http_spec.rb
+++ b/spec/occi/api/client/client_http_spec.rb
@@ -27,7 +27,7 @@ module Occi
         end
 
         it "establishes connection" do
-          @client.connected.should be_true
+          @client.connected.should be true
         end
 
         it "instantiates a compute resource using type name" do
@@ -337,7 +337,7 @@ module Occi
         end
 
         it "establishes connection" do
-          @client.connected.should be_true
+          @client.connected.should be true
         end
 
         it "lists compute resources" do


### PR DESCRIPTION
- be_false/be_true matchers replaced
