### PR TITLE
Support for multiple VO in keystone

### DIFF
--- a/lib/occi/api/client/http/authn_plugins/keystone.rb
+++ b/lib/occi/api/client/http/authn_plugins/keystone.rb
@@ -106,7 +106,17 @@ module Occi::Api::Client
           # TODO: impl match with regexp in case of multiple tenants?
           raise ::Occi::Api::Client::Errors::AuthnError,
                 "Keystone didn't return any tenants!" unless response['tenants'] && response['tenants'].first
-          tenant = response['tenants'].first['name'] if response.success?
+          for x in response['tenants']
+                tenant = x['name']
+                begin
+                    set_auth_token(tenant)
+                rescue ::Occi::Api::Client::Errors::AuthnError
+                    # Try next token
+                else
+                    # Token is ok, break
+                    break
+                end
+          end
           raise ::Occi::Api::Client::Errors::AuthnError,
                 "Unable to get a tenant from Keystone!" unless tenant
 


### PR DESCRIPTION
When an user is registered to more than one VO, Keystone-VOMS returns you the list of all the VO (tenants) the users is allowed to access, but it lets you register only to the VO to which VOMS the proxy is registered.

Therefore, in order to use rocci client with keystone and multiple VOs, you need a way to select which tenant to register or just try all the tenants until you find the one where the user is allowed to access.

This last option is not the best, since according to me it should be keystone-voms to give you only tenants to which the user is allowed to access, but it works and requires no change in the user workflow (he will select which VO to use by registering the proxy certificate to the VO VOMS). It is also just an extension to the previous workaround, from using the first tenant returned to use the first tenant returned who works, so i think it could be safely merged (beside some syntax or other error I have made, of course :) )
