### PR TITLE
Fixes #19 - endpoint handling

### DIFF
--- a/lib/occi/api/client/base/protected_helpers.rb
+++ b/lib/occi/api/client/base/protected_helpers.rb
@@ -38,6 +38,7 @@ module Occi::Api::Client
         # normalize URIs, remove trailing slashes
         endpoint = URI(endpoint)
         endpoint.path = endpoint.path.gsub(/\/+/, '/').chomp('/')
+        endpoint.query = nil
 
         endpoint
       end

--- a/lib/occi/api/client/client_http.rb
+++ b/lib/occi/api/client/client_http.rb
@@ -47,11 +47,13 @@ module Occi::Api::Client
 
       # set a global base URI for all subsequent requests
       # must be done after authN calls
-      self.class.base_uri @endpoint.to_s
+      endpoint_base_uri = "#{@endpoint.scheme}://#{@endpoint.host}"
+      endpoint_base_uri << ":#{@endpoint.port}" unless @endpoint.port == @endpoint.default_port
+      self.class.base_uri endpoint_base_uri
 
       # get model information from the endpoint
       # and create Occi::Model instance
-      model_collection = get('/-/')
+      model_collection = get("#{@endpoint.path}/-/")
       @model = get_model(model_collection)
 
       # auto-connect?

--- a/spec/occi/api/client/client_http_spec.rb
+++ b/spec/occi/api/client/client_http_spec.rb
@@ -9,6 +9,11 @@ module Occi
     vcr_options = { :record => :none }
     describe ClientHttp, :vcr => vcr_options do
 
+      context "endpoint handling" do
+        it "removes query string from endpoint"
+        it "correctly handles endpoint with path"
+      end
+
       context "using media type text/plain" do
 
         before(:each) do


### PR DESCRIPTION
Correctly handling path in `endpoint`. Path is used only for the
initial model retrieval and then discarded in favour of locations
specified in the model.