### PR TITLE
HTTP 204 No Content as an acceptable return code

### DIFF
--- a/lib/occi/api/client/http/party_wrappers.rb
+++ b/lib/occi/api/client/http/party_wrappers.rb
@@ -3,6 +3,9 @@ module Occi::Api::Client
 
     module PartyWrappers
 
+      # Acceptable responses indicating OK
+      OK_RANGE = [200, 201, 202, 204].freeze
+
       # Performs GET request and parses the responses to collections.
       #
       # @example
@@ -174,7 +177,7 @@ module Occi::Api::Client
 
       def report_failure(response)
         # Is there something to report?
-        return if response.code.between? 200, 202
+        return if OK_RANGE.include? response.code
 
         # get a human-readable response message
         response_msg = response_message(response)

--- a/lib/occi/api/version.rb
+++ b/lib/occi/api/version.rb
@@ -1,5 +1,5 @@
 module Occi
   module Api
-    VERSION = "4.3.2" unless defined?(::Occi::Api::VERSION)
+    VERSION = "4.3.3" unless defined?(::Occi::Api::VERSION)
   end
 end


### PR DESCRIPTION
HTTP 204 is an acceptable return code when no content is returned by the server.