### PR TITLE
Fixed Keystone for persistent clients

### DIFF
--- a/lib/occi/api/client/http/authn_plugins/keystone.rb
+++ b/lib/occi/api/client/http/authn_plugins/keystone.rb
@@ -12,6 +12,7 @@ module Occi::Api::Client
           set_keystone_base_url
 
           # discover Keystone API version
+          @env_ref.class.headers.delete 'X-Auth-Token'
           set_auth_token ENV['ROCCI_CLIENT_KEYSTONE_TENANT']
 
           raise ::Occi::Api::Client::Errors::AuthnError,

--- a/lib/occi/api/version.rb
+++ b/lib/occi/api/version.rb
@@ -1,5 +1,5 @@
 module Occi
   module Api
-    VERSION = "4.3.8" unless defined?(::Occi::Api::VERSION)
+    VERSION = "4.3.9" unless defined?(::Occi::Api::VERSION)
   end
 end

--- a/occi-api.gemspec
+++ b/occi-api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec}/*`.split("\n")
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'occi-core', '>= 4.3.2', '< 5'
+  gem.add_dependency 'occi-core', '>= 4.3.5', '< 5'
   gem.add_dependency 'httparty', '>= 0.13.1', '< 1'
   gem.add_dependency 'json', '>= 1.8.1', '< 3'
 


### PR DESCRIPTION
Keystone token is saved in a static (class-level) variable. When
using persistent clients (within native Ruby applications), this
can cause problems with authentication. Forced removal of the
saved token prior to re-authentication should temporarily address
this issue.
(+ rOCCI-core version bump addressing bugs which do not directly affect client libraries)