### PR TITLE
Add CA options to token authn

### DIFF
--- a/lib/occi/api/client/http/authn_plugins/token.rb
+++ b/lib/occi/api/client/http/authn_plugins/token.rb
@@ -9,6 +9,9 @@ module Occi::Api::Client
           raise ArgumentError, "Missing required option 'token' for token auth!" if @options[:token].blank?
           raise ArgumentError, "Token cannot be a multi-line string!" if @options[:token].strip.lines.count > 1
           @env_ref.class.headers['X-Auth-Token'] = @options[:token].strip
+
+          @env_ref.class.ssl_ca_path @options[:ca_path] if @options[:ca_path]
+          @env_ref.class.ssl_ca_file @options[:ca_file] if @options[:ca_file]
         end
 
       end


### PR DESCRIPTION
When using token based authentication allow passing CA related options
to verify server certificate.