### PR TITLE
Support for Keystone V3 with OAuth2 access token

### DIFF
--- a/lib/occi/api/client/http/helpers.rb
+++ b/lib/occi/api/client/http/helpers.rb
@@ -30,6 +30,8 @@ module Occi::Api::Client
                           raise ::Occi::Api::Client::Errors::AuthnError,
                                 "This authN method is for fallback only!" unless fallback
                           Http::AuthnPlugins::Keystone.new self, auth_options
+                        when "oauth2"
+                          Http::AuthnPlugins::Keystone.new self, auth_options
                         when "none", nil
                           Http::AuthnPlugins::Dummy.new self
                         else


### PR DESCRIPTION
OIDC support in CLI is provided using OAuth2 access token. This access
token must be obtained either via a refesh token or via other
OAuth2/OIDC grant types that may require web browser interaction.